### PR TITLE
Only notify by mail `passed` and `failed` openQA jobs

### DIFF
--- a/lib/openqa.rb
+++ b/lib/openqa.rb
@@ -55,7 +55,7 @@ class Openqa
 
     logger.info('openQA job done, notifying...')
 
-    notify_mail
+    notify_mail if job['result'].in?(%w[passed failed])
 
     return unless ENV.fetch('KURREN_NOTIFY_SLACK_OPENQA', false)
 


### PR DESCRIPTION
For a list of possible job result status see: https://github.com/os-autoinst/openQA/blob/744c05d2e7edb3572c6e3ee06e6f2712ad02c0d1/lib/OpenQA/Jobs/Constants.pm#L51-L65