### PR TITLE
Use Ruby 3.1.2 to prevent error when installing Xmlhash

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.1.2
           bundler-cache: true
       - run: bundle exec rubocop

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.1.2
           bundler-cache: true
       - name: Run tests
         run: |


### PR DESCRIPTION
With Ruby 3.1.3, installing Xmlhash fails due to an error in its native extensions.

Fixes #82

---

This was the last CI run which passed and it ran with Ruby 3.1.2: https://github.com/openSUSE/kurren/actions/runs/3513068853/jobs/5885464323

This is when the first time the CI ran with Ruby 3.1.3, and every run afterwards failed: https://github.com/openSUSE/kurren/actions/runs/3612996745/jobs/6098396933