### PR TITLE
Disable trello build notification by default

### DIFF
--- a/dotenv.example
+++ b/dotenv.example
@@ -7,6 +7,10 @@ KURREN_NOTIFY_SLACK_OBS=true
 # Default: false
 KURREN_NOTIFY_SLACK_OPENQA=false
 
+# Notify trello about failed OBS builds
+# Default: false
+KURREN_NOTIFY_TRELLO_OBS=false
+
 ### openQA Configuration
 # Your openQA API key
 # Default: none (you need to set this)

--- a/lib/obs.rb
+++ b/lib/obs.rb
@@ -27,8 +27,6 @@ class Obs
     @trello.status = status
     @trello.notify
 
-    return unless ENV.fetch('KURREN_NOTIFY_SLACK_OBS', true)
-
     slack_message = 'Build failed for obs-server. https://build.opensuse.org/package/live_build_log/OBS:Server:Unstable/obs-server/15.5/x86_64'
     @slack.notify(message: slack_message) if status == :failed
   end

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -4,6 +4,8 @@ class Slack
   SLACK_URL = ENV.fetch('OBS_TOOLS_SLACK_URL')
 
   def notify(message:)
+    return unless ENV.fetch('KURREN_NOTIFY_SLACK_OBS', 'false') == 'true'
+
     response = Faraday.post(SLACK_URL) do |request|
       request.headers['Content-Type'] = 'application/json'
       request.body = { text: message }.to_json

--- a/lib/trello.rb
+++ b/lib/trello.rb
@@ -11,6 +11,8 @@ class Trello
   attr_accessor :status
 
   def notify
+    return unless ENV.fetch('KURREN_NOTIFY_TRELLO_OBS', 'false') == 'true'
+
     change_card_content
     change_card_cover
   end


### PR DESCRIPTION
We don't want trello notifications anymore. Let's turn them off by default.