### PR TITLE
Update the monitoring configuration for 15.6

### DIFF
--- a/lib/amqp.rb
+++ b/lib/amqp.rb
@@ -70,7 +70,7 @@ class Amqp
     return false if payload['project'] != 'OBS:Server:Unstable'
 
     payload['package'] == 'obs-server' &&
-      payload['repository'] == '15.5' &&
+      payload['repository'] == '15.6' &&
       payload['arch'] == 'x86_64'
   end
 end

--- a/lib/obs.rb
+++ b/lib/obs.rb
@@ -27,7 +27,7 @@ class Obs
     @trello.status = status
     @trello.notify
 
-    slack_message = 'Build failed for obs-server. https://build.opensuse.org/package/live_build_log/OBS:Server:Unstable/obs-server/15.5/x86_64'
+    slack_message = 'Build failed for obs-server. https://build.opensuse.org/package/live_build_log/OBS:Server:Unstable/obs-server/15.6/x86_64'
     @slack.notify(message: slack_message) if status == :failed
   end
 


### PR DESCRIPTION
Due to the recent upgrade of our reference instance server on https://build.opensuse.org to 15.6, we need to sync the monitoring configuration.